### PR TITLE
Refactor capturing and passing dp matrix state variables

### DIFF
--- a/include/pairwise_aligner/configuration/score_model_matrix_simd_1xN.hpp
+++ b/include/pairwise_aligner/configuration/score_model_matrix_simd_1xN.hpp
@@ -27,6 +27,7 @@
 // #include <pairwise_aligner/matrix/dp_matrix_column_local.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_column.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_lane_profile.hpp>
+#include <pairwise_aligner/matrix/dp_matrix_lane.hpp>
 // #include <pairwise_aligner/matrix/dp_matrix_lane_width.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_local.hpp>
 #include <pairwise_aligner/matrix/dp_matrix.hpp>
@@ -169,7 +170,7 @@ struct traits
         auto make_dp_matrix_policy = [&] () constexpr {
 
             auto default_column = [] () {
-                return dp_matrix::column(dp_matrix::block(dp_matrix::lane_profile));
+                return dp_matrix::column(dp_matrix::block(dp_matrix::lane_profile(dp_matrix::lane)));
             };
 
             if constexpr (configuration_t::is_local)

--- a/include/pairwise_aligner/configuration/score_model_matrix_simd_saturated_1xN.hpp
+++ b/include/pairwise_aligner/configuration/score_model_matrix_simd_saturated_1xN.hpp
@@ -25,6 +25,7 @@
 #include <pairwise_aligner/dp_algorithm_template/dp_algorithm_template_standard.hpp>
 #include <pairwise_aligner/interface/interface_one_to_many_bulk.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_lane_profile.hpp>
+#include <pairwise_aligner/matrix/dp_matrix_lane.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_block.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_column_saturated_local.hpp>
 #include <pairwise_aligner/matrix/dp_matrix_column_saturated.hpp>
@@ -244,9 +245,9 @@ struct traits
 
         auto make_dp_matrix_policy = [&] () constexpr {
             if constexpr (configuration_t::is_local)
-                return dp_matrix::matrix(dp_matrix::column_saturated_local(dp_matrix::block(dp_matrix::lane_profile)));
+                return dp_matrix::matrix(dp_matrix::column_saturated_local(dp_matrix::block(dp_matrix::lane_profile(dp_matrix::lane))));
             else
-                return dp_matrix::matrix(dp_matrix::column_saturated(dp_matrix::block(dp_matrix::lane_profile)));
+                return dp_matrix::matrix(dp_matrix::column_saturated(dp_matrix::block(dp_matrix::lane_profile(dp_matrix::lane))));
         };
 
         using dp_matrix_policy_t =

--- a/include/pairwise_aligner/matrix/dp_matrix.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix.hpp
@@ -65,24 +65,27 @@ public:
 
     constexpr auto column_at(std::ptrdiff_t const index) noexcept
         -> std::invoke_result_t<dp_column_fn_t,
-                                decltype(base_t::dp_column()),
-                                decltype(base_t::dp_row()[0]),
-                                decltype(base_t::column_sequence()),
-                                decltype(seqan3::views::slice(base_t::row_sequence(), 0, 1)),
-                                decltype(base_t::substitution_model()),
-                                decltype(base_t::tracker())>
+                                decltype(dp_matrix::detail::make_dp_state(
+                                            base_t::dp_column(),
+                                            base_t::dp_row()[0],
+                                            base_t::column_sequence(),
+                                            seqan3::views::slice(base_t::row_sequence(), 0, 1),
+                                            base_t::substitution_model(),
+                                            base_t::tracker()
+                                        ))>
     {
         assert(index < base_t::column_count());
 
         std::ptrdiff_t const row_chunk_size = base_t::dp_row()[0].size() - 1;
         std::ptrdiff_t const row_offset = row_chunk_size * index;
-        return std::invoke(_dp_column_fn,
-                           base_t::dp_column(),
-                           base_t::dp_row()[index],
-                           base_t::column_sequence(),
-                           seqan3::views::slice(base_t::row_sequence(), row_offset, row_offset + row_chunk_size),
-                           base_t::substitution_model(),
-                           base_t::tracker());
+        return std::invoke(_dp_column_fn, dp_matrix::detail::make_dp_state(
+                            base_t::dp_column(),
+                            base_t::dp_row()[index],
+                            base_t::column_sequence(),
+                            seqan3::views::slice(base_t::row_sequence(), row_offset, row_offset + row_chunk_size),
+                            base_t::substitution_model(),
+                            base_t::tracker()
+                        ));
     }
 };
 

--- a/include/pairwise_aligner/matrix/dp_matrix_block.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_block.hpp
@@ -118,44 +118,51 @@ public:
     constexpr auto column_at(std::ptrdiff_t const index) noexcept
         -> decltype(base_t::make_lane(dp_matrix::detail::static_lane<lane_width_t>,
                                       base_t::lane_offset(index),
-                                      base_t::dp_column(),
-                                      base_t::dp_row(),
-                                      base_t::column_sequence(),
-                                      base_t::row_slice_at(index),
-                                      base_t::substitution_model(),
-                                      base_t::tracker()))
+                                      dp_matrix::detail::make_dp_state(
+                                        base_t::dp_column(),
+                                        base_t::dp_row(),
+                                        base_t::column_sequence(),
+                                        base_t::row_slice_at(index),
+                                        base_t::substitution_model(),
+                                        base_t::tracker()
+                                      )))
     {
         assert(index < base_t::column_count());
 
         return base_t::make_lane(dp_matrix::detail::static_lane<lane_width_t>,
                                  base_t::lane_offset(index),
-                                 base_t::dp_column(),
-                                 base_t::dp_row(),
-                                 base_t::column_sequence(),
-                                 base_t::row_slice_at(index),
-                                 base_t::substitution_model(),
-                                 base_t::tracker());
+                                 dp_matrix::detail::make_dp_state(
+                                    base_t::dp_column(),
+                                    base_t::dp_row(),
+                                    base_t::column_sequence(),
+                                    base_t::row_slice_at(index),
+                                    base_t::substitution_model(),
+                                    base_t::tracker()
+                                ));
     }
 
     constexpr auto final_lane() noexcept
         -> decltype(base_t::make_lane((dp_matrix::detail::dynamic_lane<lane_width_t>),
                                       (base_t::lane_offset(base_t::column_count() - 1)),
-                                      (base_t::dp_column()),
-                                      (base_t::dp_row()),
-                                      (base_t::column_sequence()),
-                                      (base_t::row_slice_at(0)),
-                                      (base_t::substitution_model()),
-                                      (base_t::tracker())))
+                                      dp_matrix::detail::make_dp_state(
+                                        (base_t::dp_column()),
+                                        (base_t::dp_row()),
+                                        (base_t::column_sequence()),
+                                        (base_t::row_slice_at(0)),
+                                        (base_t::substitution_model()),
+                                        (base_t::tracker())
+                                       )))
     {
         std::ptrdiff_t const last_index = base_t::column_count() - 1;
         return base_t::make_lane(dp_matrix::detail::dynamic_lane<lane_width_t>,
                                  base_t::lane_offset(last_index),
-                                 base_t::dp_column(),
-                                 base_t::dp_row(),
-                                 base_t::column_sequence(),
-                                 base_t::row_slice_at(last_index),
-                                 base_t::substitution_model(),
-                                 base_t::tracker());
+                                 dp_matrix::detail::make_dp_state(
+                                    base_t::dp_column(),
+                                    base_t::dp_row(),
+                                    base_t::column_sequence(),
+                                    base_t::row_slice_at(last_index),
+                                    base_t::substitution_model(),
+                                    base_t::tracker()));
     }
 };
 

--- a/include/pairwise_aligner/matrix/dp_matrix_block.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_block.hpp
@@ -107,10 +107,10 @@ namespace dp_matrix {
 
 namespace _block {
 
-template <typename lane_fn_t, typename lane_width_t, typename ...dp_state_t>
-class _type : public dp_matrix::detail::block_base<lane_fn_t, lane_width_t, dp_state_t...>
+template <typename lane_fn_t, typename lane_width_t, typename dp_state_t>
+class _type : public dp_matrix::detail::block_base<lane_fn_t, lane_width_t, dp_state_t>
 {
-    using base_t = dp_matrix::detail::block_base<lane_fn_t, lane_width_t, dp_state_t...>;
+    using base_t = dp_matrix::detail::block_base<lane_fn_t, lane_width_t, dp_state_t>;
 
 public:
     using base_t::base_t;
@@ -172,13 +172,10 @@ struct _fn
     constexpr auto operator()(dp_lane_fn_t && dp_lane_fn, dp_matrix::lane_width_t<lane_width> const &) const noexcept
     {
         std::tuple<dp_lane_fn_t> tmp{std::forward<dp_lane_fn_t>(dp_lane_fn)};
-        return [fwd_capture = std::move(tmp)] (auto && ...dp_state) {
+        return [fwd_capture = std::move(tmp)] <typename dp_state_t>(dp_state_t && dp_state) {
             using fwd_dp_lane_fn_t = std::tuple_element_t<0, decltype(fwd_capture)>;
-            using block_t = _type<fwd_dp_lane_fn_t,
-                                  dp_matrix::lane_width_t<lane_width>,
-                                  remove_rvalue_reference_t<decltype(dp_state)>...>;
-            return block_t{std::forward<fwd_dp_lane_fn_t &&>(get<0>(fwd_capture)),
-                           std::forward<decltype(dp_state)>(dp_state)...};
+            using block_t = _type<fwd_dp_lane_fn_t, dp_matrix::lane_width_t<lane_width>, dp_state_t>;
+            return block_t{std::forward<fwd_dp_lane_fn_t &&>(get<0>(fwd_capture)), std::move(dp_state)};
         };
     }
 

--- a/include/pairwise_aligner/matrix/dp_matrix_block_base.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_block_base.hpp
@@ -20,10 +20,10 @@ inline namespace v1
 {
 namespace dp_matrix::detail {
 
-template <typename lane_fn_t, typename lane_width_t, typename ...dp_state_t>
-class block_base : public state_handle<dp_state_t...>
+template <typename lane_fn_t, typename lane_width_t, typename dp_state_t>
+class block_base : public dp_state_t
 {
-    using base_t = state_handle<dp_state_t...>;
+    using base_t = dp_state_t;
 
     lane_fn_t _lane_fn;
 
@@ -32,8 +32,8 @@ public:
     static constexpr std::ptrdiff_t lane_width = lane_width_t::value;
 
     block_base() = delete;
-    constexpr explicit block_base(lane_fn_t lane_fn, dp_state_t ...dp_state) noexcept :
-        base_t{std::forward<dp_state_t>(dp_state)...},
+    constexpr explicit block_base(lane_fn_t lane_fn, dp_state_t && dp_state) noexcept :
+        base_t{std::move(dp_state)},
         _lane_fn{std::move(lane_fn)}
     {
         // Note the first column/row is not computed again, as they were already initialised.

--- a/include/pairwise_aligner/matrix/dp_matrix_column.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_column.hpp
@@ -71,10 +71,10 @@ namespace dp_matrix {
 
 namespace _column {
 
-template <typename block_fn_t, typename ...dp_state_t>
-class _type : public dp_matrix::detail::column_base<block_fn_t, dp_state_t...>
+template <typename block_fn_t, typename dp_state_t>
+class _type : public dp_matrix::detail::column_base<block_fn_t, dp_state_t>
 {
-    using base_t = dp_matrix::detail::column_base<block_fn_t, dp_state_t...>;
+    using base_t = dp_matrix::detail::column_base<block_fn_t, dp_state_t>;
 
 public:
     using base_t::base_t;
@@ -103,15 +103,13 @@ struct _fn
     template <typename dp_block_fn_t>
     constexpr auto operator()(dp_block_fn_t && dp_block_fn) const noexcept
     {
-        return [fwd_capture = std::tuple<dp_block_fn_t>(std::forward<dp_block_fn_t>(dp_block_fn))] (auto && ...dp_state) {
+        return [fwd_capture = std::tuple<dp_block_fn_t>(std::forward<dp_block_fn_t>(dp_block_fn))]
+                <typename dp_state_t> (dp_state_t && dp_state) {
             using fwd_dp_block_fn_t = std::tuple_element_t<0, decltype(fwd_capture)>;
             // static_assert(std::same_as<fwd_dp_block_fn_t, void>, "fwd_dp_block_fn_t");                         // seqan::pairwise_aligner::v1::dp_matrix::_block::_fn::operator()::._anon_186&&
             // static_assert(std::same_as<decltype(std::get<0>(fwd_capture)), void>, "std::get<0>(fwd_capture)"); // seqan::pairwise_aligner::v1::dp_matrix::_block::_fn::operator()::._anon_186&
-            using column_t = _type<fwd_dp_block_fn_t, remove_rvalue_reference_t<decltype(dp_state)>...>;
-            return column_t{
-                std::forward<fwd_dp_block_fn_t>(std::get<0>(fwd_capture)),
-                std::forward<decltype(dp_state)>(dp_state)...
-            };
+            using column_t = _type<fwd_dp_block_fn_t, dp_state_t>;
+            return column_t{std::forward<fwd_dp_block_fn_t>(std::get<0>(fwd_capture)), std::move(dp_state)};
         };
     }
 };

--- a/include/pairwise_aligner/matrix/dp_matrix_column_base.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_column_base.hpp
@@ -73,9 +73,10 @@ public:
 protected:
     template <typename ...args_t>
     constexpr auto make_matrix_block(args_t && ...args) const noexcept
-        -> std::invoke_result_t<block_closure_t, args_t...>
+        -> std::invoke_result_t<block_closure_t,
+                                decltype(dp_matrix::detail::make_dp_state(std::forward<args_t>(args)...))>
     {
-        return std::invoke(_block_closure, std::forward<args_t>(args)...);
+        return std::invoke(_block_closure, dp_matrix::detail::make_dp_state(std::forward<args_t>(args)...));
     }
 
 private:
@@ -143,9 +144,10 @@ protected:
     }
 
     template <typename ...args_t>
-    constexpr auto make_matrix_block(args_t && ...args) const noexcept -> std::invoke_result_t<block_fn_t, args_t...>
+    constexpr auto make_matrix_block(args_t && ...args) const noexcept ->
+        std::invoke_result_t<block_fn_t, decltype(dp_matrix::detail::make_dp_state(std::forward<args_t>(args)...))>
     {
-        return std::invoke(_block_fn, std::forward<args_t>(args)...);
+        return std::invoke(_block_fn, dp_matrix::detail::make_dp_state(std::forward<args_t>(args)...));
     }
 
 private:

--- a/include/pairwise_aligner/matrix/dp_matrix_column_base.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_column_base.hpp
@@ -109,20 +109,20 @@ private:
     }
 };
 
-template <typename block_fn_t, typename ...dp_state_t>
-class column_base : public state_handle<dp_state_t...>
+template <typename block_fn_t, typename dp_state_t>
+class column_base : public dp_state_t
 {
 protected:
 
-    using base_t = state_handle<dp_state_t...>;
+    using base_t = dp_state_t;
 
     block_fn_t _block_fn{};
 
 public:
     column_base() = delete;
 
-    constexpr explicit column_base(block_fn_t block_fn, dp_state_t ...dp_state) noexcept :
-        base_t{std::forward<dp_state_t>(dp_state)...},
+    constexpr explicit column_base(block_fn_t block_fn, dp_state_t && dp_state) noexcept :
+        base_t{std::move(dp_state)},
         _block_fn{std::move(block_fn)}
     {
         rotate_row_scores_right(base_t::dp_row());

--- a/include/pairwise_aligner/matrix/dp_matrix_lane.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_lane.hpp
@@ -178,6 +178,9 @@ class _type : public dp_matrix::detail::state_handle<dp_state_t...>
 
     cached_row_t _cached_row;
     std::ptrdiff_t _row_offset;
+protected:
+
+    using last_lane_tag_type = last_lane_tag_t;
 
 public:
 

--- a/include/pairwise_aligner/matrix/dp_matrix_lane.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_lane.hpp
@@ -169,10 +169,10 @@ namespace dp_matrix {
 // } // namespace cpo
 namespace _lane {
 
-template <typename last_lane_tag_t, typename ...dp_state_t>
-class _type : public dp_matrix::detail::state_handle<dp_state_t...>
+template <typename last_lane_tag_t, typename dp_state_t>
+class _type : public dp_state_t
 {
-    using base_t = dp_matrix::detail::state_handle<dp_state_t...>;
+    using base_t = dp_state_t;
     using dp_row_value_t = typename base_t::dp_row_type::value_type;
     using cached_row_t = std::array<dp_row_value_t, last_lane_tag_t::width>;
 
@@ -185,8 +185,8 @@ protected:
 public:
 
     _type() = delete;
-    _type(std::ptrdiff_t const offset, dp_state_t ...dp_state) noexcept :
-        base_t{std::forward<dp_state_t>(dp_state)...},
+    _type(std::ptrdiff_t const offset, dp_state_t dp_state) noexcept :
+        base_t{std::move(dp_state)},
         _row_offset{std::max<std::ptrdiff_t>(offset, 0) + 1}
     {
         if constexpr (!last_lane_tag_t::value) {
@@ -252,12 +252,12 @@ private:
 
 struct _fn
 {
-    template <typename last_lane_tag_t, typename ...dp_state_t>
-    constexpr auto operator()(last_lane_tag_t const &, std::ptrdiff_t const offset, dp_state_t && ...dp_state)
+    template <typename last_lane_tag_t, typename dp_state_t>
+    constexpr auto operator()(last_lane_tag_t const &, std::ptrdiff_t const offset, dp_state_t dp_state)
         const noexcept
     {
-        using lane_t = _type<last_lane_tag_t, dp_state_t...>;
-        return lane_t{offset, std::forward<decltype(dp_state)>(dp_state)...};
+        using lane_t = _type<last_lane_tag_t, dp_state_t>;
+        return lane_t{offset, std::move(dp_state)};
     }
 };
 } // namespace _lane

--- a/include/pairwise_aligner/matrix/dp_matrix_lane_profile.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_lane_profile.hpp
@@ -59,10 +59,10 @@ struct _fn
     constexpr auto operator()(wrappee_fn_t && wrappee_fn) const noexcept
     {
         std::tuple<wrappee_fn_t> tmp{std::forward<wrappee_fn_t>(wrappee_fn)};
-        return [fwd_capture = std::move(tmp)] (auto && ...dp_state) {
+        return [fwd_capture = std::move(tmp)] (auto && ...args) {
             using fwd_wrappee_fn_t = std::tuple_element_t<0, decltype(fwd_capture)>;
             auto wrappee = std::invoke(std::forward<fwd_wrappee_fn_t &&>(get<0>(fwd_capture)),
-                                       std::forward<decltype(dp_state)>(dp_state)...);
+                                       std::forward<decltype(args)>(args)...);
 
             return _type{std::move(wrappee)};
         };

--- a/include/pairwise_aligner/matrix/dp_matrix_lane_profile.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_lane_profile.hpp
@@ -26,11 +26,12 @@ namespace dp_matrix {
 
 namespace _lane_profile {
 
-template <typename last_lane_tag_t, typename ...dp_state_t>
-class _type : public dp_matrix::_lane::_type<last_lane_tag_t, dp_state_t...>
+template <typename wrappee_t>
+class _type : public wrappee_t
 {
-    using base_t = dp_matrix::_lane::_type<last_lane_tag_t, dp_state_t...>;
+    using base_t = wrappee_t;
     using substitution_model_t = typename base_t::substitution_model_type;
+    using last_lane_tag_t = typename base_t::last_lane_tag_type;
     using profile_t = typename substitution_model_t::template profile_type<last_lane_tag_t::width>;
 
     profile_t _profile;
@@ -38,8 +39,8 @@ class _type : public dp_matrix::_lane::_type<last_lane_tag_t, dp_state_t...>
 public:
 
     _type() = delete;
-    _type(std::ptrdiff_t const offset, dp_state_t ...dp_state) noexcept :
-        base_t{offset, std::forward<dp_state_t>(dp_state)...},
+    _type(wrappee_t wrappee) noexcept :
+        base_t{std::move(wrappee)},
         _profile{base_t::substitution_model().initialise_profile(base_t::row_sequence(),
                                                                  strip_width<last_lane_tag_t::width>)}
     {}
@@ -54,12 +55,17 @@ public:
 
 struct _fn
 {
-    template <typename last_lane_tag_t, typename ...dp_state_t>
-    constexpr auto operator()(last_lane_tag_t const &, std::ptrdiff_t const offset, dp_state_t && ...dp_state)
-        const noexcept
+    template <typename wrappee_fn_t>
+    constexpr auto operator()(wrappee_fn_t && wrappee_fn) const noexcept
     {
-        using lane_profile_t = _type<last_lane_tag_t, dp_state_t...>;
-        return lane_profile_t{offset, std::forward<decltype(dp_state)>(dp_state)...};
+        std::tuple<wrappee_fn_t> tmp{std::forward<wrappee_fn_t>(wrappee_fn)};
+        return [fwd_capture = std::move(tmp)] (auto && ...dp_state) {
+            using fwd_wrappee_fn_t = std::tuple_element_t<0, decltype(fwd_capture)>;
+            auto wrappee = std::invoke(std::forward<fwd_wrappee_fn_t &&>(get<0>(fwd_capture)),
+                                       std::forward<decltype(dp_state)>(dp_state)...);
+
+            return _type{std::move(wrappee)};
+        };
     }
 };
 } // namespace _lane_profile

--- a/include/pairwise_aligner/matrix/dp_matrix_state_handle.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_state_handle.hpp
@@ -144,6 +144,12 @@ public:
     }
 };
 
+template <typename ...args_t>
+inline constexpr auto make_dp_state(args_t && ...args) -> state_handle<args_t...>
+{
+    return state_handle<args_t...>{std::forward<args_t>(args)...};
+}
+
 } // namespace detail
 } // namespace dp_matrix
 } // inline namespace v1

--- a/include/pairwise_aligner/matrix/dp_matrix_state_handle.hpp
+++ b/include/pairwise_aligner/matrix/dp_matrix_state_handle.hpp
@@ -73,64 +73,124 @@ public:
         _dp_state_as_tuple{std::forward<dp_state_t>(dp_data)...}
     {}
 
-    constexpr dp_row_type & dp_row() noexcept
+    constexpr dp_row_type & dp_row() & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_row>>(_dp_state_as_tuple);
     }
 
-    constexpr dp_row_type const & dp_row() const noexcept
+    constexpr dp_row_type const & dp_row() const & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_row>>(_dp_state_as_tuple);
     }
 
-    constexpr dp_column_type & dp_column() noexcept
+    constexpr fwd_dp_row_t && dp_row() && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_row>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr fwd_dp_row_t const && dp_row() const && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_row>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr dp_column_type & dp_column() & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_column>>(_dp_state_as_tuple);
     }
 
-    constexpr dp_column_type const & dp_column() const noexcept
+    constexpr dp_column_type const & dp_column() const & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_column>>(_dp_state_as_tuple);
     }
 
-    constexpr column_sequence_type & column_sequence() noexcept
+    constexpr fwd_dp_column_t && dp_column() && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_column>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr fwd_dp_column_t const && dp_column() const && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_dp_column>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr column_sequence_type & column_sequence() & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_column_sequence>>(_dp_state_as_tuple);
     }
 
-    constexpr column_sequence_type const & column_sequence() const noexcept
+    constexpr column_sequence_type const & column_sequence() const & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_column_sequence>>(_dp_state_as_tuple);
     }
 
-    constexpr row_sequence_type & row_sequence() noexcept
+    constexpr fwd_column_sequence_t && column_sequence() && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_column_sequence>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr fwd_column_sequence_t const && column_sequence() const && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_column_sequence>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr row_sequence_type & row_sequence() & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_row_sequence>>(_dp_state_as_tuple);
     }
 
-    constexpr row_sequence_type const & row_sequence() const noexcept
+    constexpr row_sequence_type const & row_sequence() const & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_row_sequence>>(_dp_state_as_tuple);
     }
 
-    constexpr substitution_model_type & substitution_model() noexcept
+    constexpr fwd_row_sequence_t && row_sequence() && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_row_sequence>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr fwd_row_sequence_t const && row_sequence() const && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_row_sequence>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr substitution_model_type & substitution_model() & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_substitution_model>>(_dp_state_as_tuple);
     }
 
-    constexpr substitution_model_type const & substitution_model() const noexcept
+    constexpr substitution_model_type const & substitution_model() const & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_substitution_model>>(_dp_state_as_tuple);
     }
 
-    constexpr tracker_type & tracker() noexcept
+    constexpr fwd_substitution_model_t && substitution_model() && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_substitution_model>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr fwd_substitution_model_t const && substitution_model() const && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_substitution_model>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr tracker_type & tracker() & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_tracker>>(_dp_state_as_tuple);
     }
 
-    constexpr tracker_type const & tracker() const noexcept
+    constexpr tracker_type const & tracker() const & noexcept
     {
         return get<dp_state_accessor_id_v<dp_state_accessor::id_tracker>>(_dp_state_as_tuple);
+    }
+
+    constexpr fwd_tracker_t && tracker() && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_tracker>>(std::move(_dp_state_as_tuple));
+    }
+
+    constexpr fwd_tracker_t const && tracker() const && noexcept
+    {
+        return get<dp_state_accessor_id_v<dp_state_accessor::id_tracker>>(std::move(_dp_state_as_tuple));
     }
 
     constexpr std::ptrdiff_t column_count() const noexcept

--- a/include/pairwise_aligner/simd/simd_rank_selector.hpp
+++ b/include/pairwise_aligner/simd/simd_rank_selector.hpp
@@ -27,7 +27,6 @@ inline namespace v1
 namespace detail {
 
 template <typename key_t>
-    requires ((detail::max_simd_size == 1) || (key_t::size_v != detail::max_simd_size))
 struct simd_rank_selector_default
 {
 protected:

--- a/test/unit/matrix/CMakeLists.txt
+++ b/test/unit/matrix/CMakeLists.txt
@@ -1,0 +1,1 @@
+pairwise_aligner_test (state_handle_test.cpp)

--- a/test/unit/matrix/state_handle_test.cpp
+++ b/test/unit/matrix/state_handle_test.cpp
@@ -1,0 +1,133 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/rrahn/pairwise_aligner/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <pairwise_aligner/matrix/dp_matrix_state_handle.hpp>
+
+namespace pa = seqan::pairwise_aligner;
+
+struct object {
+    int value{42};
+};
+
+TEST(state_handle_test, lvalue_state_with_lvalue_ref_members) {
+
+    object obj{};
+    auto state = pa::dp_matrix::detail::make_dp_state(obj, obj, obj, obj, obj, obj);
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object &, object &, object &, object &, object &, object &>>));
+
+    EXPECT_TRUE((std::same_as<decltype(state.dp_column()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.dp_row()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.column_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.row_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.substitution_model()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.tracker()), object &>));
+
+}
+
+TEST(state_handle_test, const_lvalue_state_with_lvalue_ref_members) {
+    object obj{};
+    auto state = pa::dp_matrix::detail::make_dp_state(obj, obj, obj, obj, obj, obj);
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object &, object &, object &, object &, object &, object &>>));
+
+    auto const & c_state = std::as_const(state);
+    EXPECT_TRUE((std::same_as<decltype(c_state.dp_column()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.dp_row()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.column_sequence()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.row_sequence()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.substitution_model()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.tracker()), object const &>));
+}
+
+TEST(state_handle_test, rvalue_state_with_lvalue_ref_members) {
+    object obj{};
+    auto state = pa::dp_matrix::detail::make_dp_state(obj, obj, obj, obj, obj, obj);
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object &, object &, object &, object &, object &, object &>>));
+
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).dp_column()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).dp_row()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).column_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).row_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).substitution_model()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).tracker()), object &>));
+}
+
+TEST(state_handle_test, rvalue_const_state_with_lvalue_ref_members) {
+    object obj{};
+    auto state = pa::dp_matrix::detail::make_dp_state(obj, obj, obj, obj, obj, obj);
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object &, object &, object &, object &, object &, object &>>));
+
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).dp_column()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).dp_row()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).column_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).row_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).substitution_model()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).tracker()), object &>));
+}
+
+TEST(state_handle_test, lvalue_state_with_moved_members) {
+
+    auto state = pa::dp_matrix::detail::make_dp_state(object{}, object{}, object{}, object{}, object{}, object{});
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object, object, object, object, object, object>>));
+
+    EXPECT_TRUE((std::same_as<decltype(state.dp_column()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.dp_row()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.column_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.row_sequence()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.substitution_model()), object &>));
+    EXPECT_TRUE((std::same_as<decltype(state.tracker()), object &>));
+
+}
+
+TEST(state_handle_test, const_lvalue_state_with_moved_members) {
+
+    auto state = pa::dp_matrix::detail::make_dp_state(object{}, object{}, object{}, object{}, object{}, object{});
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object, object, object, object, object, object>>));
+
+    auto const & c_state = std::as_const(state);
+    EXPECT_TRUE((std::same_as<decltype(c_state.dp_column()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.dp_row()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.column_sequence()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.row_sequence()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.substitution_model()), object const &>));
+    EXPECT_TRUE((std::same_as<decltype(c_state.tracker()), object const &>));
+}
+
+TEST(state_handle_test, rvalue_state_with_moved_members) {
+
+    auto state = pa::dp_matrix::detail::make_dp_state(object{}, object{}, object{}, object{}, object{}, object{});
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object, object, object, object, object, object>>));
+
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).dp_column()), object &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).dp_row()), object &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).column_sequence()), object &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).row_sequence()), object &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).substitution_model()), object &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(state).tracker()), object &&>));
+}
+
+TEST(state_handle_test, rvalue_const_state_with_moved_members) {
+
+    auto state = pa::dp_matrix::detail::make_dp_state(object{}, object{}, object{}, object{}, object{}, object{});
+    EXPECT_TRUE((std::same_as<decltype(state),
+                 pa::dp_matrix::detail::state_handle<object, object, object, object, object, object>>));
+
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).dp_column()), object const &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).dp_row()), object const &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).column_sequence()), object const &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).row_sequence()), object const &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).substitution_model()), object const &&>));
+    EXPECT_TRUE((std::same_as<decltype(std::move(std::as_const(state)).tracker()), object const &&>));
+}


### PR DESCRIPTION
This simplifies the adaptors that need to wrap some of the state variables into special wrappers, e.g. the saturated dp adaptors or the local dp matrix adaptor.